### PR TITLE
Move credentials to headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ The service exposes a few endpoints to interact with bots:
 - `GET /get-messages` – fetch recent messages from the chat with the bot
 - `POST /reset-chat` – clear dialog history with the bot
 
+Custom Telegram credentials can be provided via HTTP headers:
+
+- `X-Telegram-Api-Id`
+- `X-Telegram-Api-Hash`
+- `X-Telegram-Session-String`
+
 ## Running tests with a real bot
 
 The test suite can interact with a live Telegram bot if you provide the required credentials:

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from dotenv import load_dotenv
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Header, Depends
 from telethon import TelegramClient, events # Import events
 from telethon.sessions import StringSession
 from telethon import types
@@ -106,6 +106,14 @@ async def get_telegram_client(
 
 # Old event handlers are removed as their logic is now in the lifespan manager.
 
+async def get_header_credentials(
+    api_id: Optional[int] = Header(None, alias="X-Telegram-Api-Id"),
+    api_hash: Optional[str] = Header(None, alias="X-Telegram-Api-Hash"),
+    session_string: Optional[str] = Header(None, alias="X-Telegram-Session-String"),
+) -> TelegramCredentialsRequest:
+    """Extract optional Telegram credentials from request headers."""
+    return TelegramCredentialsRequest(api_id=api_id, api_hash=api_hash, session_string=session_string)
+
 def _parse_buttons(message: types.Message) -> Optional[List[List[MessageButton]]]:
     if not message.buttons:
         return None
@@ -130,11 +138,13 @@ def _parse_buttons(message: types.Message) -> Optional[List[List[MessageButton]]
 
 
 @app.post("/send-message", response_model=BotResponse)
-async def send_message(req: SendMessageRequest) -> BotResponse:
-    creds = req.credentials
-    api_id = creds.api_id if creds else None
-    api_hash = creds.api_hash if creds else None
-    session_string = creds.session_string if creds else None
+async def send_message(
+    req: SendMessageRequest,
+    creds: TelegramCredentialsRequest = Depends(get_header_credentials),
+) -> BotResponse:
+    api_id = creds.api_id
+    api_hash = creds.api_hash
+    session_string = creds.session_string
 
     async with get_telegram_client(api_id, api_hash, session_string) as current_client:
         entity = await current_client.get_input_entity(req.bot_username)
@@ -151,14 +161,16 @@ async def send_message(req: SendMessageRequest) -> BotResponse:
 
 
 @app.post("/press-button", response_model=BotResponse)
-async def press_button(req: PressButtonRequest) -> BotResponse:
+async def press_button(
+    req: PressButtonRequest,
+    creds: TelegramCredentialsRequest = Depends(get_header_credentials),
+) -> BotResponse:
     if not req.button_text and not req.callback_data:
         raise HTTPException(status_code=400, detail="button_text or callback_data required")
 
-    creds = req.credentials
-    api_id = creds.api_id if creds else None
-    api_hash = creds.api_hash if creds else None
-    session_string = creds.session_string if creds else None
+    api_id = creds.api_id
+    api_hash = creds.api_hash
+    session_string = creds.session_string
 
     async with get_telegram_client(api_id, api_hash, session_string) as current_client:
         entity = await current_client.get_input_entity(req.bot_username)
@@ -214,10 +226,11 @@ async def press_button(req: PressButtonRequest) -> BotResponse:
 async def get_messages(
     bot_username: str,
     limit: int = 5,
-    api_id: Optional[int] = Query(None, description="Custom API ID"),
-    api_hash: Optional[str] = Query(None, description="Custom API Hash"),
-    session_string: Optional[str] = Query(None, description="Custom Session String")
+    creds: TelegramCredentialsRequest = Depends(get_header_credentials),
 ) -> GetMessagesResponse:
+    api_id = creds.api_id
+    api_hash = creds.api_hash
+    session_string = creds.session_string
     async with get_telegram_client(api_id, api_hash, session_string) as current_client:
         entity = await current_client.get_input_entity(bot_username)
         messages = await current_client.get_messages(entity, limit=limit)

--- a/src/models.py
+++ b/src/models.py
@@ -18,14 +18,12 @@ class SendMessageRequest(BaseModel):
     bot_username: str
     message_text: str
     timeout_sec: int = 10
-    credentials: Optional[TelegramCredentialsRequest] = None
 
 class PressButtonRequest(BaseModel):
     bot_username: str
     button_text: Optional[str] = None
     callback_data: Optional[str] = None
     timeout_sec: int = 10
-    credentials: Optional[TelegramCredentialsRequest] = None
 
 class GetMessagesResponse(BaseModel):
     messages: List[BotResponse]


### PR DESCRIPTION
## Summary
- accept Telegram API credentials via HTTP headers
- adjust pydantic models
- document the new headers in the README

## Testing
- `uv run --extra test pytest -s -o log_cli=true -o log_cli_level=INFO` *(fails: .env.test file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c219dc4c8328b7c5a9c08b0a4b3e