### PR TITLE
Add TypeScript client

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ Custom Telegram credentials can be provided via HTTP headers:
 - `X-Telegram-Api-Hash`
 - `X-Telegram-Session-String`
 
+## TypeScript client
+
+A small TypeScript client is available in `ts-client`. Build it with:
+
+```bash
+cd ts-client
+npm install
+npm run build
+```
+
+Usage example:
+
+```ts
+import TeletestApiClient from "teletest-api-client";
+const client = new TeletestApiClient("http://localhost:8000");
+client.sendMessage({ bot_username: "mybot", message_text: "/ping" }).then(console.log);
+```
+
 ## Running tests with a real bot
 
 The test suite can interact with a live Telegram bot if you provide the required credentials:

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "teletest-api-client",
+  "version": "0.1.0",
+  "description": "TypeScript client for teletest-api",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "axios": "^1.6.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/ts-client/src/index.ts
+++ b/ts-client/src/index.ts
@@ -1,0 +1,71 @@
+import axios, { AxiosInstance } from 'axios';
+
+export interface TelegramCredentialsRequest {
+  api_id?: number;
+  api_hash?: string;
+  session_string?: string;
+}
+
+export interface MessageButton {
+  text: string;
+  callback_data?: string | null;
+}
+
+export interface BotResponse {
+  message_text: string;
+  reply_markup?: MessageButton[][] | null;
+}
+
+export interface SendMessageRequest {
+  bot_username: string;
+  message_text: string;
+  timeout_sec?: number;
+}
+
+export interface PressButtonRequest {
+  bot_username: string;
+  button_text?: string;
+  callback_data?: string;
+  timeout_sec?: number;
+}
+
+export interface GetMessagesResponse {
+  messages: BotResponse[];
+}
+
+function buildHeaders(creds?: TelegramCredentialsRequest): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (!creds) return headers;
+  if (creds.api_id !== undefined) headers['X-Telegram-Api-Id'] = String(creds.api_id);
+  if (creds.api_hash !== undefined) headers['X-Telegram-Api-Hash'] = creds.api_hash;
+  if (creds.session_string !== undefined) headers['X-Telegram-Session-String'] = creds.session_string;
+  return headers;
+}
+
+export class TeletestApiClient {
+  constructor(private baseUrl: string, private http: AxiosInstance = axios.create()) {}
+
+  async sendMessage(req: SendMessageRequest, creds?: TelegramCredentialsRequest): Promise<BotResponse> {
+    const resp = await this.http.post<BotResponse>(`${this.baseUrl}/send-message`, req, {
+      headers: buildHeaders(creds)
+    });
+    return resp.data;
+  }
+
+  async pressButton(req: PressButtonRequest, creds?: TelegramCredentialsRequest): Promise<BotResponse> {
+    const resp = await this.http.post<BotResponse>(`${this.baseUrl}/press-button`, req, {
+      headers: buildHeaders(creds)
+    });
+    return resp.data;
+  }
+
+  async getMessages(bot_username: string, limit = 5, creds?: TelegramCredentialsRequest): Promise<GetMessagesResponse> {
+    const resp = await this.http.get<GetMessagesResponse>(`${this.baseUrl}/get-messages`, {
+      headers: buildHeaders(creds),
+      params: { bot_username, limit }
+    });
+    return resp.data;
+  }
+}
+
+export default TeletestApiClient;

--- a/ts-client/tsconfig.json
+++ b/ts-client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript client library under `ts-client`
- document the client usage in README

## Testing
- `uv run pytest -s -o log_cli=true -o log_cli_level=INFO` *(fails: .env.test not found)*

------
https://chatgpt.com/codex/tasks/task_e_68670a6d9d148328a1ab6012d88d5555