### PR TITLE
Add DEBUG env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 API_ID=1234567
 API_HASH="your_api_hash_here"
 SESSION_STRING="your_session_string_here"
+# Enable debug logging by setting DEBUG to 1 or true
+DEBUG=0
 # TELEGRAM_TEST_BOT_USERNAME will be fetched dynamically by tests
 
 # For test purposes

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ A small FastAPI service for testing Telegram bots with a real user account via T
 - `API_HASH` – your API hash
 - `SESSION_STRING` – session string for the account
 
+    Optional variables:
+
+- `DEBUG` – set to `1` or `true` to enable verbose debug logging
+
 To obtain the session string you can run the helper script:
 
 ```bash

--- a/src/app.py
+++ b/src/app.py
@@ -22,7 +22,9 @@ from .models import (
 
 load_dotenv()  # Load environment variables from .env file
 
-logging.basicConfig(level=logging.INFO)
+# Configure logging level based on DEBUG env variable
+DEBUG_MODE = os.getenv("DEBUG", "0").lower() in ("1", "true", "yes")
+logging.basicConfig(level=logging.DEBUG if DEBUG_MODE else logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Default credentials from environment variables

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,12 @@ import logging
 # Configure logging for conftest
 # To see these logs with pytest, you might need:
 # pytest -o log_cli=true -o log_cli_level=INFO -s (the -s flag captures stdout/stderr and loggin)
+debug_mode = os.getenv("DEBUG", "0").lower() in ("1", "true", "yes")
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.DEBUG if debug_mode else logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Summary
- toggle debug logging via DEBUG env var
- adjust tests to respect DEBUG
- document DEBUG env var in README and .env.example

## Testing
- `ruff check .`
- `pytest -q` *(fails: TEST_BOT_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_6868f60c0a3883289ae437088c0d242e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enabling verbose debug logging by setting the `DEBUG` environment variable.

* **Documentation**
  * Updated the README to document the new optional `DEBUG` environment variable and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->