### PR TITLE
fix: Improve timeout handling for async operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "python-dotenv",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "ruff>=0.12.0",
 ]

--- a/src/models.py
+++ b/src/models.py
@@ -33,13 +33,13 @@ class BotResponse(BaseModel):
 class SendMessageRequest(BaseModel):
     bot_username: str
     message_text: str
-    timeout_sec: int = 10
+    timeout_sec: int = 5
 
 class PressButtonRequest(BaseModel):
     bot_username: str
     button_text: Optional[str] = None
     callback_data: Optional[str] = None
-    timeout_sec: int = 10
+    timeout_sec: int = 5
 
 class GetMessagesResponse(BaseModel):
     messages: List[BotResponse]

--- a/tests/real_bot/main.py
+++ b/tests/real_bot/main.py
@@ -82,6 +82,13 @@ async def ack_test(message: types.Message):
 async def handle_just_ack_button(callback_query: types.CallbackQuery):
     await callback_query.answer("Acknowledged!") # This text might appear as a brief notification
 
+# Command to test bot responding with a delay of 3 seconds
+@dp.message(Command("delay_test"))
+async def delay_test(message: types.Message):
+    await message.answer("Waiting for 3 seconds...")
+    await asyncio.sleep(3)
+    await message.answer("Done waiting!")
+
 # Generic callback handler for unhandled callback data (must be after specific ones)
 @dp.callback_query()
 async def callback_other(callback_query: types.CallbackQuery):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -351,3 +351,18 @@ def test_ack_callback(app, ping_bot):
         assert not any(r.get("message_text") for r in press_responses), \
             f"Pressing 'Just Ack' should not result in new messages, got: {press_responses}"
 
+def test_delay_test(app, ping_bot):
+    bot_username = os.getenv("TELEGRAM_TEST_BOT_USERNAME")
+    assert bot_username, "TELEGRAM_TEST_BOT_USERNAME environment variable not set"
+    with TestClient(app) as client:
+        # 1. Send /delay_test to get the message with the button
+        resp_send = client.post(
+            "/send-message",
+            json={"bot_username": bot_username, "message_text": "/delay_test", "timeout_sec": 5},
+        )
+        assert resp_send.status_code == 200
+        send_responses = resp_send.json()
+
+        assert len(send_responses) == 2, f"Expected 2 messages from /delay_test, got: {send_responses}"
+        assert send_responses[0]["message_text"] == "Waiting for 3 seconds..."
+        assert send_responses[1]["message_text"] == "Done waiting!"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [manifest]
 members = [
-    "src",
+    "teletest-api",
     "teletest-python-client",
 ]
 
@@ -659,7 +659,19 @@ wheels = [
 ]
 
 [[package]]
-name = "src"
+name = "starlette"
+version = "0.46.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037 },
+]
+
+[[package]]
+name = "teletest-api"
 version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
@@ -669,7 +681,7 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
-[package.dev-dependencies]
+[package.optional-dependencies]
 dev = [
     { name = "ruff" },
 ]
@@ -682,32 +694,17 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiogram", marker = "extra == 'test'", specifier = ">=3.20.0.post0" },
     { name = "fastapi" },
+    { name = "httpx", marker = "extra == 'test'", specifier = ">=0.28.1" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.1" },
+    { name = "pytest-rerunfailures", marker = "extra == 'test'", specifier = ">=13.0" },
     { name = "python-dotenv" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
     { name = "telethon" },
     { name = "uvicorn" },
 ]
-
-[package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.12.0" }]
-test = [
-    { name = "aiogram", specifier = ">=3.20.0.post0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-rerunfailures", specifier = ">=13.0" },
-]
-
-[[package]]
-name = "starlette"
-version = "0.46.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037 },
-]
+provides-extras = ["dev", "test"]
 
 [[package]]
 name = "teletest-python-client"


### PR DESCRIPTION
This pull request introduces several updates to improve the handling of asynchronous operations, refactor configuration, and enhance testing. Key changes include transitioning synchronous methods to asynchronous ones, refining timeout handling, and adding new test cases for bot functionality.

### Asynchronous Improvements:
* Updated `start()` method calls to use `await` in `async def get_telegram_client` to ensure proper asynchronous execution (`src/app.py`) [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L112-R113) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L127-R128).
* Refactored response collection loops in `send_message` and `press_button` to dynamically calculate remaining time for better timeout management (`src/app.py`) [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L182-R207) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L244-R262) [[3]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R271-R278).

### Configuration Updates:
* Replaced `[dependency-groups]` with `[project.optional-dependencies]` in `pyproject.toml` for better compatibility with modern Python packaging standards (`pyproject.toml`).
* Reduced default `timeout_sec` from 10 to 5 seconds in `SendMessageRequest` and `PressButtonRequest` models to align with expected response times (`src/models.py`).

### Testing Enhancements:
* Added a new `/delay_test` command to simulate delayed bot responses and verify handling of delayed interactions (`tests/real_bot/main.py`).
* Introduced a test case `test_delay_test` to validate the `/delay_test` command functionality, ensuring proper message sequencing and timeout behavior (`tests/test_app.py`).