### PR TITLE
Add reply keyboard test

### DIFF
--- a/clients/python-client/teletest_api_client.py
+++ b/clients/python-client/teletest_api_client.py
@@ -42,6 +42,7 @@ class BotResponse:
     message_id: Optional[int] = None
     message_text: Optional[str] = None
     reply_markup: Optional[List[List[MessageButton]]] = None
+    reply_keyboard: Optional[bool] = None
     callback_answer_text: Optional[str] = None
     callback_answer_alert: Optional[bool] = None
     popup_message: Optional[str] = None
@@ -97,6 +98,7 @@ class TeletestApiClient:
             message_id=resp.get("message_id"),
             message_text=resp.get("message_text"),
             reply_markup=self._parse_reply_markup(resp.get("reply_markup")),
+            reply_keyboard=resp.get("reply_keyboard"),
             callback_answer_text=resp.get("callback_answer_text"),
             callback_answer_alert=resp.get("callback_answer_alert"),
             popup_message=resp.get("popup_message"),

--- a/clients/ts-client/src/index.ts
+++ b/clients/ts-client/src/index.ts
@@ -22,6 +22,7 @@ export interface BotResponse {
   message_id?: number;
   message_text?: string;
   reply_markup?: MessageButton[][] | null;
+  reply_keyboard?: boolean | null;
   callback_answer_text?: string;
   callback_answer_alert?: boolean;
   popup_message?: string;

--- a/src/models.py
+++ b/src/models.py
@@ -22,6 +22,7 @@ class BotResponse(BaseModel):
     message_id: Optional[int] = None # For MESSAGE, EDITED_MESSAGE
     message_text: Optional[str] = None  # For MESSAGE, EDITED_MESSAGE
     reply_markup: Optional[List[List[MessageButton]]] = None # For MESSAGE, EDITED_MESSAGE
+    reply_keyboard: Optional[bool] = None  # True if reply markup is a ReplyKeyboardMarkup
     
     # For CALLBACK_ANSWER
     callback_answer_text: Optional[str] = None

--- a/tests/real_bot/main.py
+++ b/tests/real_bot/main.py
@@ -1,7 +1,13 @@
 import os
 import asyncio
 from aiogram import Bot, Dispatcher, types
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from aiogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    ReplyKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardRemove,
+)
 from aiogram.filters import Command
 
 BOT_TOKEN = os.getenv("TEST_BOT_TOKEN")
@@ -88,6 +94,30 @@ async def delay_test(message: types.Message):
     await message.answer("Waiting for 3 seconds...")
     await asyncio.sleep(3)
     await message.answer("Done waiting!")
+
+# Command to test reply keyboard
+@dp.message(Command("reply_kb"))
+async def reply_kb(message: types.Message):
+    keyboard = ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text="Option 1")],
+            [KeyboardButton(text="Option 2")],
+        ],
+        resize_keyboard=True,
+    )
+    await message.answer("Choose an option:", reply_markup=keyboard)
+
+@dp.message(lambda m: m.text == "Option 1")
+async def handle_option1(message: types.Message):
+    await message.answer("You chose option 1")
+
+@dp.message(lambda m: m.text == "Option 2")
+async def handle_option2(message: types.Message):
+    await message.answer("You chose option 2")
+
+@dp.message(Command("remove_kb"))
+async def remove_kb(message: types.Message):
+    await message.answer("Keyboard removed", reply_markup=ReplyKeyboardRemove())
 
 # Generic callback handler for unhandled callback data (must be after specific ones)
 @dp.callback_query()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -383,6 +383,7 @@ def test_reply_keyboard(app, ping_bot):
         choose_msg = find_message_with_text(show_responses, "Choose an option:")
         assert choose_msg, f"Did not find reply keyboard message in {show_responses}"
         assert choose_msg["reply_markup"], "Reply keyboard not present on message"
+        assert choose_msg["reply_keyboard"] is True
         assert choose_msg["reply_markup"][0][0]["text"] == "Option 1"
 
         # Select first option using send_message
@@ -394,6 +395,7 @@ def test_reply_keyboard(app, ping_bot):
         press_responses = resp_press.json()
         selected = find_message_with_text(press_responses, "You chose option 1")
         assert selected, f"Response to reply keyboard selection not found in {press_responses}"
+        assert selected["reply_keyboard"] is False
 
         # Remove keyboard to not interfere with other tests
         resp_remove = client.post(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -366,3 +366,41 @@ def test_delay_test(app, ping_bot):
         assert len(send_responses) == 2, f"Expected 2 messages from /delay_test, got: {send_responses}"
         assert send_responses[0]["message_text"] == "Waiting for 3 seconds..."
         assert send_responses[1]["message_text"] == "Done waiting!"
+
+
+def test_reply_keyboard(app, ping_bot):
+    bot_username = os.getenv("TELEGRAM_TEST_BOT_USERNAME")
+    assert bot_username, "TELEGRAM_TEST_BOT_USERNAME environment variable not set"
+    with TestClient(app) as client:
+        # Send command to show reply keyboard
+        resp_show = client.post(
+            "/send-message",
+            json={"bot_username": bot_username, "message_text": "/reply_kb", "timeout_sec": 5},
+        )
+        assert resp_show.status_code == 200
+        show_responses = resp_show.json()
+
+        choose_msg = find_message_with_text(show_responses, "Choose an option:")
+        assert choose_msg, f"Did not find reply keyboard message in {show_responses}"
+        assert choose_msg["reply_markup"], "Reply keyboard not present on message"
+        assert choose_msg["reply_markup"][0][0]["text"] == "Option 1"
+
+        # Select first option using send_message
+        resp_press = client.post(
+            "/send-message",
+            json={"bot_username": bot_username, "message_text": "Option 1", "timeout_sec": 5},
+        )
+        assert resp_press.status_code == 200
+        press_responses = resp_press.json()
+        selected = find_message_with_text(press_responses, "You chose option 1")
+        assert selected, f"Response to reply keyboard selection not found in {press_responses}"
+
+        # Remove keyboard to not interfere with other tests
+        resp_remove = client.post(
+            "/send-message",
+            json={"bot_username": bot_username, "message_text": "/remove_kb", "timeout_sec": 5},
+        )
+        assert resp_remove.status_code == 200
+        remove_responses = resp_remove.json()
+        remove_msg = find_message_with_text(remove_responses, "Keyboard removed")
+        assert remove_msg, f"Remove keyboard response not found in {remove_responses}"


### PR DESCRIPTION
## Summary
- add `reply_kb` command to the test bot
- add tests for reply keyboard usage and cleanup

## Testing
- `ruff check .`
- `pytest -q` *(fails: cannot connect to api.telegram.org)*

------
https://chatgpt.com/codex/tasks/task_e_6869061e3fec8328b593a4aa37e2da12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reply keyboards in the bot, allowing users to select from presented options and remove the keyboard with a command.

* **Tests**
  * Introduced a new test to verify reply keyboard functionality, including option selection and keyboard removal.

* **Enhancements**
  * Improved message response handling to distinguish and return both inline and reply keyboard markups.
  * Updated client APIs to explicitly indicate the presence of reply keyboards in bot responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->