### PR TITLE
Add response logging middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ API_HASH="your_api_hash_here"
 SESSION_STRING="your_session_string_here"
 # Enable debug logging by setting DEBUG to 1 or true
 DEBUG=0
+# Enable response body logging by setting VERBOSE to 1 or true
+VERBOSE=0
 # TELEGRAM_TEST_BOT_USERNAME will be fetched dynamically by tests
 
 # For test purposes

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A small FastAPI service for testing Telegram bots with a real user account via T
     Optional variables:
 
 - `DEBUG` – set to `1` or `true` to enable verbose debug logging
+- `VERBOSE` – set to `1` or `true` to log response bodies
 
 To obtain the session string you can run the helper script:
 


### PR DESCRIPTION
## Summary
- add `LogResponseBodyMiddleware` to inspect API responses
- enable middleware when `VERBOSE` env variable is set
- document new variable and example usage

## Testing
- `pytest -q` *(fails: cannot reach api.telegram.org)*

------
https://chatgpt.com/codex/tasks/task_e_68694c5c551c83289f97f49162aa52e8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional environment variable to enable detailed logging of HTTP response bodies.
  * Introduced middleware that logs the status code, method, URL path, and response body when this variable is enabled.

* **Documentation**
  * Updated the README and environment variable example file to document the new logging option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->